### PR TITLE
Enable blog entries

### DIFF
--- a/githubnotifier.py
+++ b/githubnotifier.py
@@ -193,9 +193,9 @@ class GithubFeedUpdatherThread(threading.Thread):
             n = {'title': user.get('name', user['login']),
                  'message': message,
                  'icon': user['avatar_path']}
-            
+
             if item['author'] == GITHUB_BLOG_USER:
-                n['icon'] = os.path.join(os.path.abspath('octocat.png'))
+                n['icon'] = os.path.abspath('octocat.png')
 
             l.append(n)
 


### PR DESCRIPTION
Close #2

Add:
- Option to enable notifications of new blog entries
- GitHub blog entry author icon to use the octocat.png
- GitHub blog entry author information to be 'GitHub Blog'

Refactor:
- How octocat.png path is used (now just uses the absolute path)
