### PR TITLE
Fixed problem with the avatar

### DIFF
--- a/githubnotifier.py
+++ b/githubnotifier.py
@@ -417,7 +417,8 @@ class GithubFeedUpdatherThread(threading.Thread):
 
         for item in notifications:
             if not item['author'] in users:
-                users[item['author']] = get_github_user_info(item['author'])
+                users[item['author']] = get_github_user_info(
+                                            item['author'].split(" ")[0])
 
             user = users[item['author']]
             if self.hyperlinks and 'link' in item:


### PR DESCRIPTION
When the feeds show author's email the avatar and the user information can't be downloaded. I fixed with a simple split of the string. 
