### PR TITLE
help users track down issues easier - would have helped #23

### DIFF
--- a/githubnotifier.py
+++ b/githubnotifier.py
@@ -326,8 +326,8 @@ class GithubFeedUpdatherThread(threading.Thread):
         self.logger = logging.getLogger('github-notifier')
 
         self.feeds = [
-            'http://github.com/%s.private.atom?token=%s' % (user, token),
-            'http://github.com/%s.private.actor.atom?token=%s' % (user, token),
+            'https://github.com/%s.private.atom?token=%s' % (user, token),
+            'https://github.com/%s.private.actor.atom?token=%s' % (user, token),
         ]
 
         if blog:
@@ -391,7 +391,9 @@ class GithubFeedUpdatherThread(threading.Thread):
         feed = feedparser.parse(feed_url)
 
         if self.is_problematic_http_code( str(feed.status) ):
-            self.logger.error('Feed answered with %s - %s' % (feed.status, httplib.responses.get(feed.status)))
+            message = 'Feed answered with %s - %s%sFor URL: %s' % \
+                      (feed.status, httplib.responses.get(feed.status), os.linesep, feed.href)
+            self.logger.error(message)
         else:
             self.logger.info('Feed answered with %s' % feed.status)
 

--- a/githubnotifier.py
+++ b/githubnotifier.py
@@ -36,6 +36,33 @@ GITHUB_URL = 'https://github.com/'
 
 notification_queue = Queue.Queue()
 
+http_error_codes = {
+    301: "Moved Permanently",
+    400: "Bad Request",
+    401: "Unauthorized",
+    402  "Payment Required",
+    403: "Forbidden",
+    404: "Not Found"
+    405: "Method Not Allowed",
+    406: "Not Acceptable",
+    407: "Proxy Authentication Required",
+    408: "Request Timeout",
+    410: "Gone",
+    411: "Length Required",
+    413: "Payload Too Larg",
+    414: "URI Too Long",
+    415: "Unsupported Media Type",
+    416: "Range Not Satisfiable",
+    417: "Expectation Failed",
+    423: "Locked",
+    500: "Internal Server Error",
+    501: "Not Implemented",
+    502: "Bad Gateway",
+    503: "Service Unavailable",
+    504: "Gateway Timeout",
+    505: "HTTP Version Not Supporte"
+}
+
 
 def get_github_config():
     fp = os.popen('git config --get github.user')
@@ -388,6 +415,10 @@ class GithubFeedUpdatherThread(threading.Thread):
             return []
 
         feed = feedparser.parse(feed_url)
+        if http_error_codes.get(feed.status):
+            self.logger.error('Feed answered with %s %s' % (http_error_codes.get(feed.status), feed.status))
+        else:
+            self.logger.info('Feed answered with %s ' % feed.status)
 
         notifications = []
         for entry in feed.entries:


### PR DESCRIPTION
I agree with [the author of feedparser, about not changing urls.](https://pythonhosted.org/feedparser/http-redirect.html).
>Repeatedly requesting the original address of a feed that has been permanently redirected is very rude, and may get you banned from the server.

Here is my verbose output after this patch:
```
[INFO] 10 May 03:29:27
github-notifier is capable of using hyperlinks
[INFO] 10 May 03:29:27
Creating system tray icon
[INFO] 10 May 03:29:27
Fetching feed http://github.com/dotnetCarpenter.private.atom?token=AACq88ajoAWbD5PMpBLJW4Smd8byV3Yyks63HikYwA==
[INFO] 10 May 03:29:27
Enabling feeds organizations
[ERROR] 10 May 03:29:31
Feed answered with 301 - Moved Permanently
[INFO] 10 May 03:29:31
Fetching feed http://github.com/dotnetCarpenter.private.actor.atom?token=AACq88ajoAWbD5PMpBLJW4Smd8byV3Yyks63HikYwA==
[ERROR] 10 May 03:29:32
Feed answered with 301 - Moved Permanently
[INFO] 10 May 03:29:32
Fetching feed https://github.com/organizations/IT-Kollektivet/dotnetCarpenter.private.atom?token=AACq88ajoAWbD5PMpBLJW4Smd8byV3Yyks63HikYwA==
[ERROR] 10 May 03:29:33
Feed answered with 401 - Unauthorized
[INFO] 10 May 03:29:33
Fetching feed https://github.com/organizations/Firefund/dotnetCarpenter.private.atom?token=AACq88ajoAWbD5PMpBLJW4Smd8byV3Yyks63HikYwA==
[ERROR] 10 May 03:29:33
Feed answered with 401 - Unauthorized
[INFO] 10 May 03:29:33
Fetching feed https://github.com/organizations/traitsjs/dotnetCarpenter.private.atom?token=AACq88ajoAWbD5PMpBLJW4Smd8byV3Yyks63HikYwA==
[ERROR] 10 May 03:29:34
Feed answered with 401 - Unauthorized
[INFO] 10 May 03:29:34
Found item entry
[INFO] 10 May 03:29:34
Found item entry
[INFO] 10 May 03:29:34
Found item entry
```

I'll see if I can find the correct URL's and update this PR.

The HTTP error codes are not complete - I only included the ones that I think could ever matter to a project like github-notifier. So there is more than enough but obviously not all.